### PR TITLE
Dequeue tests from the end of the file queue

### DIFF
--- a/lib/parallel_tests/fine_grain_test/file_queue.rb
+++ b/lib/parallel_tests/fine_grain_test/file_queue.rb
@@ -29,11 +29,14 @@ module ParallelTests
 
       def deq
         lock do |file|
-          lines = file.read.split(/\n/)
+          contents = file.read
+          lines = contents.split(/\n/)
           return nil if lines.empty? || lines[0].chomp == MARKER
-          rewrite(file, lines[1..-1])
 
-          return TestCase.decode(lines[0].chomp)
+          new_size = contents.bytesize - lines.last.bytesize - 1
+          file.truncate new_size
+
+          return TestCase.decode(lines.last.chomp)
         end
       end
 

--- a/test/parallel_tests/fine_grain_test/file_queue_test.rb
+++ b/test/parallel_tests/fine_grain_test/file_queue_test.rb
@@ -99,14 +99,20 @@ module ParallelTests
         assert_equal nil, @file_queue.deq
       end
 
-      def test_deq__should_remove_and_return_first_case
-        File.write(@file_name, "#{self.class.name} one\n#{self.class.name} two")
+      def test_deq__should_remove_and_return_last_case
+        File.write(@file_name, "#{self.class.name} one\n#{self.class.name} two\n")
+
+        test_case = @file_queue.deq
+
+        assert_equal self.class, test_case.suite
+        assert_equal 'two', test_case.name
+        assert_equal 1, @file_queue.size
 
         test_case = @file_queue.deq
 
         assert_equal self.class, test_case.suite
         assert_equal 'one', test_case.name
-        assert_equal 1, @file_queue.size
+        assert_equal 0, @file_queue.size
       end
     end
   end


### PR DESCRIPTION
This gem works by writing all test names to a text file and using that file as a work queue: workers all get an exclusive lock to the file, read off the first line, truncate the file to 0 bytes, re-write to the file all of the remaining tests, release the lock, run their test, and repeat.

On large projects with >= 10,000 tests, the task of rewriting the test queue file can be expensive. In the tests of a large propriety project running in parallel using 16 processes, we found the amount of (wall clock) time any one process spends waiting to an exclusive lock is about 100 seconds.

This change optimizes how we remove a test from the file queue. Instead of reading the _first_ test off the queue file and rewriting the remaining tests, worker processes will read the _last_ test from the list, then [`truncate(2)`][0] the file in a way that keeps everything except that last test. Technically, this makes the "file queue" more like a "file stack" since it's LIFO and not FIFO, but in practice, I don't think it really matters.

On the same project with 16 processes, the amount of time any one process waits for the exclusive lock to the queue file is reduced to around 5 seconds.

Further optimizations are of course possible: it's not necessary to _read_ the entire file into memory to get just the last test. Really, we just need to find the position of the second-to-last newline character while reading the file backwards. Then we can just truncate the file to the index past the second-to-last-newline. I left this optimization out for now.

[0]: https://linux.die.net/man/2/truncate