### PR TITLE
Write test queue to file in reverse order

### DIFF
--- a/lib/parallel_tests/fine_grain_test/file_queue.rb
+++ b/lib/parallel_tests/fine_grain_test/file_queue.rb
@@ -22,7 +22,7 @@ module ParallelTests
 
           test_cases = yield(test_cases) if block_given?
 
-          lines = test_cases.map { |test_case| TestCase.encode(test_case) }
+          lines = test_cases.map { |test_case| TestCase.encode(test_case) }.reverse
           rewrite(file, lines)
         end
       end

--- a/test/parallel_tests/fine_grain_test/file_queue_test.rb
+++ b/test/parallel_tests/fine_grain_test/file_queue_test.rb
@@ -64,6 +64,25 @@ module ParallelTests
         assert_equal 3, @file_queue.size
       end
 
+      def test_enq_all__should_write_tests_in_reverse_order
+        test_cases = [
+          TestCase.new(self.class, "one"),
+          TestCase.new(self.class, "two"),
+          TestCase.new(self.class, "three"),
+        ]
+
+        @file_queue.reset
+        @file_queue.enq_all(test_cases)
+
+        lines = File.readlines(@file_name)
+        expected_lines = [
+          "#{self.class.name} three\n",
+          "#{self.class.name} two\n",
+          "#{self.class.name} one\n",
+        ]
+        assert_equal expected_lines, lines
+      end
+
       def test_enq_all__should_not_enque_when_file_empty
         test_cases = [
           TestCase.new(self, "one"),


### PR DESCRIPTION
Tests are pulled from the end of the file first. So when we enqueue
them, we should put the first test at the end of the file.

This is important when using the `FINE_GRAIN_TEST_RUNTIME_LOGGER` option
to run slowest tests first. 2ad6ffde75fe8ea8b052d44c1084153433ffc906
actually made it so that slowest tests run last by mistake.