### PR TITLE
Capture NameError when decoding test case name

### DIFF
--- a/lib/parallel_tests/fine_grain_test/test_case.rb
+++ b/lib/parallel_tests/fine_grain_test/test_case.rb
@@ -9,7 +9,12 @@ module ParallelTests
       def self.decode(string)
         suite, name = string.split(/ /, 2)
         name = name.gsub("\\n", "\n").gsub("\\\\", "\\")
-        new(Object.module_eval("::#{suite}", __FILE__, __LINE__), name)
+        suite_object = begin
+                         Object.module_eval("::#{suite}", __FILE__, __LINE__)
+                       rescue NameError
+                         nil
+                       end
+        new(suite_object, name) if suite_object
       end
 
       def ==(other)

--- a/test/parallel_tests/fine_grain_test/test_case_test.rb
+++ b/test/parallel_tests/fine_grain_test/test_case_test.rb
@@ -48,6 +48,12 @@ module ParallelTests
         assert_equal self.class, test_case.suite
         assert_equal "hello\\there", test_case.name
       end
+
+      def test_decode__should_return_nil_when_suite_is_not_defined
+        str = "ParallelTests::FineGrainTest::DoesNotExist hello\\\\there"
+
+        assert_nil TestCase.decode(str)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixing the following problem:

1. Run a test suite using `FINE_GRAIN_TEST_RUNTIME_LOGGER=times.txt`. This records all of the tests timings along with the test class names and the test names.
2. Delete a test file
3. Run the test suite with again with `FINE_GRAIN_TEST_RUNTIME_LOGGER=times.txt`

Expected:

The test suite runs the slowest tests first, using what information is available in `times.txt`.

Observed:

`NameError` is raised in `TestCase#decode` when it encounters a test case in `times.txt` that uses the deleted test file.